### PR TITLE
create error log in tempdir

### DIFF
--- a/R/cognito_idp.R
+++ b/R/cognito_idp.R
@@ -7,19 +7,21 @@ library(jsonlite)
 #'
 #' @return A character vector of the usernames of the users in the group.
 precisely.aws.CognitoIdp.getUsersInGroup <- function(userPoolId, groupName) {
+  error_log <- paste0(tempdir(), "error.log")
+
   output <- tryCatch(
     {
       args <- c("cognito-idp",
                 "list-users-in-group",
                 "--user-pool-id", userPoolId,
                 "--group-name", groupName)
-      system2("aws", args = args, stdout = TRUE, stderr = "./error.log")
+      system2("aws", args = args, stdout = TRUE, stderr = error_log)
     },
     error = function (cond) {
       stop("aws command not found, failing")
     },
     warning = function (cond) {
-      error_msg <- readr::read_lines("./error.log", skip_empty_rows = TRUE)
+      error_msg <- readr::read_lines(error_log, skip_empty_rows = TRUE)
       stop(error_msg)
     }
   )

--- a/R/secrets_manager.R
+++ b/R/secrets_manager.R
@@ -11,6 +11,8 @@ library(jsonlite)
 #' @param versionStage The staging label attached to the version of the secret to retrieve (optional).
 #' @return list of the parsed JSON of the SecretString
 precisely.aws.SecretsManager.getSecretValue <- function(secretId, versionId, versionStage) {
+  error_log <- paste0(tempdir(), "error.log")
+
   output <- tryCatch(
     {
       args <- c("secretsmanager", "get-secret-value", "--secret-id", secretId)
@@ -20,13 +22,13 @@ precisely.aws.SecretsManager.getSecretValue <- function(secretId, versionId, ver
       if (!missing(versionStage)) {
         args <- c(args, "--version-stage", versionStage)
       }
-      system2("aws", args = args, stdout = TRUE, stderr = "./error.log")
+      system2("aws", args = args, stdout = TRUE, stderr = error_log)
     },
     error = function (cond) {
       stop("aws command not found, failing")
     },
     warning = function (cond) {
-      error_msg <- readr::read_lines("./error.log", skip_empty_rows = TRUE)
+      error_msg <- readr::read_lines(error_log, skip_empty_rows = TRUE)
       stop(error_msg)
     }
   )


### PR DESCRIPTION
Using `./error.log` as the path to the error log created by `precisely.aws.SecretsManager.getSecretValue` and `precisely.aws.CognitoIdp.getUsersInGroup` led to the following error when the functions were called in a deployed Docker container: 

```
Error: './error.log' does not exist in current working directory ('/srv/shiny-server').
sh: 1: cannot create ./error.log: Permission denied
```

Changing the path to the error log to be in `tempdir()` resolved the issue. 