### PR TITLE
Feature/KBI-73 - Added `prefix` Parameter to S3 Commands

### DIFF
--- a/tests/testthat/test_s3.R
+++ b/tests/testthat/test_s3.R
@@ -11,7 +11,9 @@ test_that("test file appears in bucket list", {
 })
 
 test_that("test file is successfully downloaded", {
-  expect_identical(precisely.aws.S3.get_object("s3_test_file.txt", "precisely-aws-test", "./tmp.txt"),
+  expect_identical(precisely.aws.S3.get_object("s3_test_file.txt",
+                                               "precisely-aws-test",
+                                               "./tmp.txt"),
                    "download: s3://precisely-aws-test/s3_test_file.txt to ./tmp.txt")
   expect_true(file.exists("./tmp.txt"))
   expect_identical(readLines("./tmp.txt"), "DO NOT DELETE. For testing purposes only.")
@@ -21,6 +23,38 @@ test_that("test file is successfully downloaded", {
 test_that("test file is successfully deleted", {
   expect_identical(precisely.aws.S3.delete_object("s3_test_file.txt", "precisely-aws-test"),
                    "delete: s3://precisely-aws-test/s3_test_file.txt")
+  expect_null(precisely.aws.S3.list_objects("precisely-aws-test"))
+})
+
+test_that("test file is successfully uploaded with prefix", {
+  expect_identical(precisely.aws.S3.put_object("./s3/s3_test_file.txt",
+                                               bucket = "precisely-aws-test",
+                                               prefix = "prefix_test"),
+                   "upload: s3/s3_test_file.txt to s3://precisely-aws-test/prefix_test/s3_test_file.txt")
+})
+
+test_that("test file appears in bucket list with prefix", {
+  objects_tbl <- precisely.aws.S3.list_objects("precisely-aws-test", prefix = "prefix_test")
+  print(objects_tbl)
+  expect_identical(objects_tbl$file_name, "prefix_test/s3_test_file.txt")
+})
+
+test_that("test file is successfully downloaded with prefix", {
+  expect_identical(precisely.aws.S3.get_object("s3_test_file.txt",
+                                               "precisely-aws-test",
+                                               "./tmp.txt",
+                                               prefix = "prefix_test"),
+                   "download: s3://precisely-aws-test/prefix_test/s3_test_file.txt to ./tmp.txt")
+  expect_true(file.exists("./tmp.txt"))
+  expect_identical(readLines("./tmp.txt"), "DO NOT DELETE. For testing purposes only.")
+  file.remove("./tmp.txt")
+})
+
+test_that("test file is successfully deleted with prefix", {
+  expect_identical(precisely.aws.S3.delete_object("s3_test_file.txt",
+                                                  "precisely-aws-test",
+                                                  prefix = "prefix_test"),
+                   "delete: s3://precisely-aws-test/prefix_test/s3_test_file.txt")
   expect_null(precisely.aws.S3.list_objects("precisely-aws-test"))
 })
 

--- a/tests/testthat/test_s3.R
+++ b/tests/testthat/test_s3.R
@@ -35,7 +35,6 @@ test_that("test file is successfully uploaded with prefix", {
 
 test_that("test file appears in bucket list with prefix", {
   objects_tbl <- precisely.aws.S3.list_objects("precisely-aws-test", prefix = "prefix_test")
-  print(objects_tbl)
   expect_identical(objects_tbl$file_name, "prefix_test/s3_test_file.txt")
 })
 


### PR DESCRIPTION
As part of the [changes](https://github.com/precision-analytics/kisoji-platform/pull/33) for performing a second round of selections in the KisoJi portal, the ability to upload, download, delete, and list objects in S3 using an optional `prefix` parameter was required. 